### PR TITLE
Make this codemod executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 A [jscodeshift](https://github.com/facebook/jscodeshift) based codemod to help migrating your jQuery based Ember tests to [ember-native-dom-helpers](https://github.com/cibernox/ember-native-dom-helpers).
 
-*Please note that this will not be able to cover all possible cases how jQuery based tests can be written. 
+*Please note that this will not be able to cover all possible cases how jQuery based tests can be written.
 Given the dynamic nature of JavaScript and the extensive API and fluent interface of jQuery, this would be impossible.
-Instead this codemod focuses to cover the most common usages and do those transformations that it can safely do. 
-So it is likely that you will have to manually migrate some usages this tool cannot cover!*  
+Instead this codemod focuses to cover the most common usages and do those transformations that it can safely do.
+So it is likely that you will have to manually migrate some usages this tool cannot cover!*
 
 ## Usage
 
@@ -20,10 +20,9 @@ repository like Git and that you have no outstanding changes to commit before
 running this tool.
 
 ```bash
-npm install jscodeshift -g
-git clone https://github.com/simonihmig/ember-native-dom-helpers-codemod
-cd my-ember-app
-jscodeshift -t ../ember-native-dom-helpers-codemod tests/integration
+npm install -g ember-native-dom-helpers-codemod
+cd my-ember-app-or-addon
+ember-native-dom-helpers-codemod tests/integration
 ```
 
 ## Transformations
@@ -57,7 +56,6 @@ If you want to run only selected transforms on your code, you can just the neede
 ```bash
 jscodeshift -t ../ember-native-dom-helpers-codemod/lib/transforms/click.js tests/integration
 ```
-
 
 ### Acceptance tests
 

--- a/bin/ember-native-dom-helpers-codemod.js
+++ b/bin/ember-native-dom-helpers-codemod.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+const spawn = require("child_process").spawn;
+const chalk = require("chalk");
+const path = require("path");
+
+try {
+  let binPath = path.dirname(require.resolve("jscodeshift")) + "/bin/jscodeshift.sh";
+  let transformPath = __dirname + "/../index.js";
+  let targetDir = process.argv[2];
+  let transform = spawn(binPath, ["-t", transformPath, targetDir], {
+    stdio: "inherit",
+    env: process.env
+  });
+} catch (e) {
+  console.error(chalk.red(e.stack));
+  process.exit(-1);
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "author": "Simon Ihmig <ihmig@kaliber5.de>",
   "license": "MIT",
+  "bin": "./bin/ember-native-dom-helpers-codemod.js",
   "scripts": {
     "test": "mocha"
   },


### PR DESCRIPTION
With this changes, the codemod becomes a simple executable if installed globally and doesn't require users to install jscodeshift themselves.

New simplified usage, assuming this package is published.

```bash
npm install -g ember-native-dom-helpers-codemod 
cd my-ember-app-or-addon
ember-native-dom-helpers-codemod tests/integration
```

I'm not sure how to run only specific transformations, I'll check it again another day.