### PR TITLE
Fix another edge case with single-line arrow functions.

### DIFF
--- a/lib/transforms/integration/set-value.js
+++ b/lib/transforms/integration/set-value.js
@@ -38,27 +38,25 @@ function createBlurExpression(j, selector) {
  */
 function isJQueryExpression(j, path) {
   let node = path.node;
-  let grandGrandParent = path.parent.parent.parent.node;
   return j.CallExpression.check(node)
     && j.MemberExpression.check(node.callee)
     && isJQuerySelectExpression(j, node.callee.object)
     && j.Identifier.check(node.callee.property)
     && node.callee.property.name === 'val'
     && node.arguments.length > 0
-    && !j.ArrowFunctionExpression.check(grandGrandParent);
+    && !j.ArrowFunctionExpression.check(path.parent.parent.parent.node);
 }
 
 function hasFluentTriggerCall(j, path) {
   let parent = path.parent && path.parent.node;
   let grandParent = parent && path.parent.parent.node;
-  let grandGrandParent = parent && path.parent.parent.parent.node;
   return parent
     && grandParent
     && j.MemberExpression.check(parent)
     && j.Identifier.check(parent.property)
     && parent.property.name === 'trigger'
     && j.CallExpression.check(grandParent)
-    && !j.ArrowFunctionExpression.check(grandGrandParent)
+    && !j.ArrowFunctionExpression.check(parent && path.parent.parent.parent.node)
     ;
 }
 

--- a/lib/transforms/integration/set-value.js
+++ b/lib/transforms/integration/set-value.js
@@ -30,30 +30,35 @@ function createBlurExpression(j, selector) {
 }
 
 /**
- * Check if `node` is a `this.$(selector).val(someValue)` expression
+ * Check if `node` is a `this.$(selector).val(someValue)` expression not in an arrow function
  *
  * @param j
  * @param node
  * @returns {*|boolean}
  */
-function isJQueryExpression(j, node) {
+function isJQueryExpression(j, path) {
+  let node = path.node;
+  let grandGrandParent = path.parent.parent.parent.node;
   return j.CallExpression.check(node)
     && j.MemberExpression.check(node.callee)
     && isJQuerySelectExpression(j, node.callee.object)
     && j.Identifier.check(node.callee.property)
     && node.callee.property.name === 'val'
-    && node.arguments.length > 0;
+    && node.arguments.length > 0
+    && !j.ArrowFunctionExpression.check(grandGrandParent);
 }
 
 function hasFluentTriggerCall(j, path) {
   let parent = path.parent && path.parent.node;
   let grandParent = parent && path.parent.parent.node;
+  let grandGrandParent = parent && path.parent.parent.parent.node;
   return parent
     && grandParent
     && j.MemberExpression.check(parent)
     && j.Identifier.check(parent.property)
     && parent.property.name === 'trigger'
     && j.CallExpression.check(grandParent)
+    && !j.ArrowFunctionExpression.check(grandGrandParent)
     ;
 }
 
@@ -86,7 +91,7 @@ function transform(file, api) {
 
   let replacements = root
     .find(j.CallExpression)
-    .filter(({ node }) => isJQueryExpression(j, node))
+    .filter((path) => isJQueryExpression(j, path))
     .replaceWith(({ node }) => createExpression(j, node.callee.object.arguments[0], node.arguments[0]))
     .forEach((path) => makeParentFunctionAsync(j, path));
 

--- a/test/integration/expected-output/set-value.js
+++ b/test/integration/expected-output/set-value.js
@@ -1,4 +1,5 @@
 import { fillIn, blur } from 'ember-native-dom-helpers';
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -13,8 +14,6 @@ test('it renders', async function(assert) {
   await fillIn('.foo', 'bar');
   await blur('.foo');
   await fillIn('.foo', 'baz');
-  await fillIn('select', '1');
-  await blur('select')
-
+  Ember.run(() => this.$('select').val('1').trigger('change'));
   assert.ok(true);
 });

--- a/test/integration/expected-output/set-value.js
+++ b/test/integration/expected-output/set-value.js
@@ -13,5 +13,8 @@ test('it renders', async function(assert) {
   await fillIn('.foo', 'bar');
   await blur('.foo');
   await fillIn('.foo', 'baz');
+  await fillIn('select', '1');
+  await blur('select')
+
   assert.ok(true);
 });

--- a/test/integration/input/set-value.js
+++ b/test/integration/input/set-value.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -11,5 +12,6 @@ test('it renders', function(assert) {
   this.$('.foo').val('foo');
   this.$('.foo').val('bar').change();
   this.$('.foo').val('baz').trigger('input');
+  Ember.run(() => this.$('select').val('1').trigger('change'));
   assert.ok(true);
 });


### PR DESCRIPTION
This demonstrate a real case that fails, along with what I think would be the ideal generated code.

`Ember.run(() => this.$('select').val('1').trigger('change'))` seems to break.
I think that it's because the transformation tries to transform it into
```
Ember.run(() => 
  await fillIn(...)
  await triggerEvent('change');
)
```
but arrow function without braces are expressions and that's invalid.

Since wrapping this kind of interactions in Ember.run is not needed, we could detect that and remove it.