### PR TITLE
Add tail eq support

### DIFF
--- a/lib/transforms/acceptance/attr.js
+++ b/lib/transforms/acceptance/attr.js
@@ -1,4 +1,4 @@
-const { createFindExpression, createPropExpression, isFindExpression, addImportStatement } = require('../../utils');
+const { createFindExpression, createPropExpression, isFindExpression, addImportStatement, writeImportStatements } = require('../../utils');
 
 /**
  * Creates a `find(selector).getAttribute(attr)` expression
@@ -70,9 +70,10 @@ function transform(file, api) {
     .replaceWith(({ node }) => createAttributeExpression(j, node.callee.object.arguments, node.arguments[0]));
 
   if (propReplacements.length > 0 || attrReplacements.length > 0) {
-    addImportStatement(j, root, ['find']);
+    addImportStatement(['find']);
   }
 
+  writeImportStatements(j, root);
   return root.toSource({ quote: 'single' });
 }
 

--- a/lib/transforms/acceptance/click.js
+++ b/lib/transforms/acceptance/click.js
@@ -1,4 +1,4 @@
-const { makeAwait, dropAndThen, addImportStatement } = require('../../utils');
+const { makeAwait, dropAndThen, addImportStatement, writeImportStatements } = require('../../utils');
 
 /**
  * Check if `node` is a `click(selector)` expression
@@ -34,9 +34,10 @@ function transform(file, api) {
   if (replacements.length > 0) {
     makeAwait(j, replacements);
     dropAndThen(j, root);
-    addImportStatement(j, root, ['click']);
+    addImportStatement(['click']);
   }
 
+  writeImportStatements(j, root);
   return root.toSource({ quote: 'single' });
 }
 

--- a/lib/transforms/acceptance/fill-in.js
+++ b/lib/transforms/acceptance/fill-in.js
@@ -1,4 +1,4 @@
-const { makeAwait, dropAndThen, addImportStatement } = require('../../utils');
+const { makeAwait, dropAndThen, addImportStatement, writeImportStatements } = require('../../utils');
 
 /**
  * Check if `node` is a `fillIn(selector)` expression
@@ -35,9 +35,10 @@ function transform(file, api) {
   if (replacements.length > 0) {
     makeAwait(j, replacements);
     dropAndThen(j, root);
-    addImportStatement(j, root, ['fillIn']);
+    addImportStatement(['fillIn']);
   }
 
+  writeImportStatements(j, root);
   return root.toSource({ quote: 'single' });
 }
 

--- a/lib/transforms/acceptance/get-value.js
+++ b/lib/transforms/acceptance/get-value.js
@@ -1,4 +1,4 @@
-const { createFindExpression, isFindExpression, addImportStatement } = require('../../utils');
+const { createFindExpression, isFindExpression, addImportStatement, writeImportStatements } = require('../../utils');
 
 /**
  * Creates a `find(selector).value` expression
@@ -49,9 +49,10 @@ function transform(file, api) {
     .replaceWith(({ node }) => createExpression(j, node.callee.object.arguments));
 
   if (replacements.length > 0) {
-    addImportStatement(j, root, ['find']);
+    addImportStatement(['find']);
   }
 
+  writeImportStatements(j, root);
   return root.toSource({quote: 'single'});
 }
 

--- a/lib/transforms/acceptance/has-class.js
+++ b/lib/transforms/acceptance/has-class.js
@@ -1,4 +1,4 @@
-const { createFindExpression, isFindExpression, addImportStatement } = require('../../utils');
+const { createFindExpression, isFindExpression, addImportStatement, writeImportStatements } = require('../../utils');
 
 /**
  * Creates a `find(selector).classList.contains(className)` expression
@@ -55,9 +55,10 @@ function transform(file, api) {
     .replaceWith(({ node }) => createExpression(j, node.callee.object.arguments, node.arguments[0]));
 
   if (replacements.length > 0) {
-    addImportStatement(j, root, ['find']);
+    addImportStatement(['find']);
   }
 
+  writeImportStatements(j, root);
   return root.toSource({ quote: 'single' });
 }
 

--- a/lib/transforms/acceptance/html.js
+++ b/lib/transforms/acceptance/html.js
@@ -1,4 +1,4 @@
-const { createFindExpression, isFindExpression, addImportStatement } = require('../../utils');
+const { createFindExpression, isFindExpression, addImportStatement, writeImportStatements } = require('../../utils');
 
 /**
  * Creates a `find(selector).innerHTML` expression
@@ -49,9 +49,10 @@ function transform(file, api) {
     .replaceWith(({ node }) => createExpression(j, node.callee.object.arguments));
 
   if (replacements.length > 0) {
-    addImportStatement(j, root, ['find']);
+    addImportStatement(['find']);
   }
 
+  writeImportStatements(j, root);
   return root.toSource({quote: 'single'});
 }
 

--- a/lib/transforms/acceptance/key-event.js
+++ b/lib/transforms/acceptance/key-event.js
@@ -1,4 +1,4 @@
-const { makeAwait, dropAndThen, addImportStatement } = require('../../utils');
+const { makeAwait, dropAndThen, addImportStatement, writeImportStatements } = require('../../utils');
 
 /**
  * Check if `node` is a `keyEvent(...)` expression
@@ -34,9 +34,10 @@ function transform(file, api) {
   if (replacements.length > 0) {
     makeAwait(j, replacements);
     dropAndThen(j, root);
-    addImportStatement(j, root, ['keyEvent']);
+    addImportStatement(['keyEvent']);
   }
 
+  writeImportStatements(j, root);
   return root.toSource({ quote: 'single' });
 }
 

--- a/lib/transforms/acceptance/length.js
+++ b/lib/transforms/acceptance/length.js
@@ -1,4 +1,4 @@
-const { createFindAllExpression, isFindExpression, addImportStatement } = require('../../utils');
+const { createFindAllExpression, isFindExpression, addImportStatement, writeImportStatements } = require('../../utils');
 
 /**
  * Creates a `findAll(selector).length` expression
@@ -47,8 +47,10 @@ function transform(file, api) {
     .replaceWith(({ node }) => createExpression(j, node.object.arguments));
 
   if (replacements.length > 0) {
-    addImportStatement(j, root, ['findAll']);
+    addImportStatement(['findAll']);
   }
+
+  writeImportStatements(j, root);
   return root.toSource({quote: 'single'});
 }
 

--- a/lib/transforms/acceptance/prop.js
+++ b/lib/transforms/acceptance/prop.js
@@ -1,4 +1,4 @@
-const { createPropExpression, isFindExpression, addImportStatement } = require('../../utils');
+const { createPropExpression, isFindExpression, addImportStatement, writeImportStatements } = require('../../utils');
 
 /**
  * Check if `node` is a `this.$(selector).prop('propName')` expression
@@ -37,9 +37,10 @@ function transform(file, api) {
     ;
 
   if (replacements.length > 0) {
-    addImportStatement(j, root, ['find']);
+    addImportStatement(['find']);
   }
 
+  writeImportStatements(j, root);
   return root.toSource({ quote: 'single' });
 }
 

--- a/lib/transforms/acceptance/route-helpers.js
+++ b/lib/transforms/acceptance/route-helpers.js
@@ -1,4 +1,4 @@
-const { addImportStatement } = require('../../utils');
+const { addImportStatement, writeImportStatements } = require('../../utils');
 
 /**
  * Check if `node` is a currentURL, currentPath, currentRouteName call
@@ -35,10 +35,11 @@ function transform(file, api) {
        .find(j.CallExpression)
        .filter(({ node }) => isRouteHelperExpression(j, node, type))
        .length > 0) {
-     addImportStatement(j, root, [type]);
+     addImportStatement([type]);
    }
  });
 
+  writeImportStatements(j, root);
   return root.toSource({ quote: 'single' });
 }
 

--- a/lib/transforms/acceptance/tail-eq.js
+++ b/lib/transforms/acceptance/tail-eq.js
@@ -1,4 +1,4 @@
-const { addImportStatement, createArraySubscriptExpression, createFindAllExpression, writeImportStatements } = require('../../utils');
+const { addImportStatement, createArraySubscriptExpression, createFindAllExpression, migrateSelector, writeImportStatements } = require('../../utils');
 
 const sizzleFunctions = [ 'find', 'click', 'fillIn' ];
 
@@ -37,16 +37,9 @@ function transform(file, api) {
     .find(j.CallExpression)
     .filter(({ node }) => isAnEqExpression(j, node))
     .replaceWith(({ node }) => {
-      let [, selector, eqIndex ] = node.arguments[0].value.match(/(.+?):eq\((\d+)\)$/);
-      node.arguments[0].value = selector;
-
-      let eqExpression = createArraySubscriptExpression(j, createFindAllExpression(j, node.arguments.slice(0, 1)), +eqIndex);
-      if (node.callee.name === 'find') {
-        return eqExpression;
-      } else {
-        node.arguments = [ eqExpression, ...node.arguments.slice(1) ];
-        return node;
-      }
+      let eqExpression = migrateSelector(j, node.arguments[0]);
+      node.arguments = [ eqExpression, ...node.arguments.slice(1) ];
+      return node;
     })
     ;
 

--- a/lib/transforms/acceptance/tail-eq.js
+++ b/lib/transforms/acceptance/tail-eq.js
@@ -1,0 +1,60 @@
+const { addImportStatement, createArraySubscriptExpression, createFindAllExpression } = require('../../utils');
+
+const sizzleFunctions = [ 'find', 'click', 'fillIn' ];
+
+/**
+ * Check if `node` is a selector function call with an :eq pattern as an argument
+ *
+ * @param j
+ * @param node
+ * @returns {*|boolean}
+ */
+function isAnEqExpression(j, node) {
+  return j.CallExpression.check(node)
+    && j.Identifier.check(node.callee)
+    && sizzleFunctions.includes(node.callee.name)
+    && j.Literal.check(node.arguments[0])
+    && typeof node.arguments[0].value === 'string'
+    && /:eq\(\d+\)$/.test(node.arguments[0].value)
+    ;
+}
+
+/**
+ * Transform `find(selector:eq(#))` to `findAll(selector)[#]`
+ * and `click(selector:eq(#))` to `click(findAll(selector)[#])`
+ *
+ * @param file
+ * @param api
+ * @returns {*|string}
+ */
+function transform(file, api) {
+  let source = file.source;
+  let j = api.jscodeshift;
+
+  let root = j(source);
+
+  let replacements = root
+    .find(j.CallExpression)
+    .filter(({ node }) => isAnEqExpression(j, node))
+    .replaceWith(({ node }) => {
+      let [, selector, eqIndex ] = node.arguments[0].value.match(/(.+?):eq\((\d+)\)$/);
+      node.arguments[0].value = selector;
+
+      let eqExpression = createArraySubscriptExpression(j, createFindAllExpression(j, node.arguments.slice(0, 1)), +eqIndex);
+      if (node.callee.name === 'find') {
+        return eqExpression;
+      } else {
+        node.arguments = [ eqExpression, ...node.arguments.slice(1) ];
+        return node;
+      }
+    })
+    ;
+
+  if (replacements.length > 0) {
+    addImportStatement(j, root, ['findAll']);
+  }
+
+  return root.toSource({ quote: 'single' });
+}
+
+module.exports = transform;

--- a/lib/transforms/acceptance/tail-eq.js
+++ b/lib/transforms/acceptance/tail-eq.js
@@ -1,4 +1,4 @@
-const { addImportStatement, createArraySubscriptExpression, createFindAllExpression } = require('../../utils');
+const { addImportStatement, createArraySubscriptExpression, createFindAllExpression, writeImportStatements } = require('../../utils');
 
 const sizzleFunctions = [ 'find', 'click', 'fillIn' ];
 
@@ -51,9 +51,10 @@ function transform(file, api) {
     ;
 
   if (replacements.length > 0) {
-    addImportStatement(j, root, ['findAll']);
+    addImportStatement(['findAll']);
   }
 
+  writeImportStatements(j, root);
   return root.toSource({ quote: 'single' });
 }
 

--- a/lib/transforms/acceptance/text.js
+++ b/lib/transforms/acceptance/text.js
@@ -1,4 +1,4 @@
-const { createFindExpression, isFindExpression, addImportStatement } = require('../../utils');
+const { createFindExpression, isFindExpression, addImportStatement, writeImportStatements } = require('../../utils');
 
 /**
  * Creates a `find(selector).textContent` expression
@@ -48,9 +48,10 @@ function transform(file, api) {
     .replaceWith(({ node }) => createExpression(j, node.callee.object.arguments));
 
   if (replacements.length > 0) {
-    addImportStatement(j, root, ['find']);
+    addImportStatement(['find']);
   }
 
+  writeImportStatements(j, root);
   return root.toSource({quote: 'single'});
 }
 

--- a/lib/transforms/acceptance/trigger-event.js
+++ b/lib/transforms/acceptance/trigger-event.js
@@ -1,4 +1,4 @@
-const { createFocusExpression, createBlurExpression, makeAwait, dropAndThen, addImportStatement } = require('../../utils');
+const { createFocusExpression, createBlurExpression, makeAwait, dropAndThen, addImportStatement, writeImportStatements } = require('../../utils');
 
 /**
  * Check if `node` is a `triggerEvent(...)` expression
@@ -46,24 +46,25 @@ function transform(file, api) {
   if (blurReplacements.length > 0) {
     blurReplacements
       .replaceWith(({ node }) => createBlurExpression(j, node.arguments[0]));
-    addImportStatement(j, root, ['blur']);
+    addImportStatement(['blur']);
   }
 
   if (focusReplacements.length > 0) {
     focusReplacements
       .replaceWith(({ node }) => createFocusExpression(j, node.arguments[0]));
-    addImportStatement(j, root, ['focus']);
+    addImportStatement(['focus']);
   }
 
   if (triggerReplacements.length > 0) {
     makeAwait(j, triggerReplacements);
-    addImportStatement(j, root, ['triggerEvent']);
+    addImportStatement(['triggerEvent']);
   }
 
   if (replacements.length > 0) {
     dropAndThen(j, root);
   }
 
+  writeImportStatements(j, root);
   return root.toSource({ quote: 'single' });
 }
 

--- a/lib/transforms/acceptance/visit.js
+++ b/lib/transforms/acceptance/visit.js
@@ -1,4 +1,4 @@
-const { makeAwait, dropAndThen, addImportStatement } = require('../../utils');
+const { makeAwait, dropAndThen, addImportStatement, writeImportStatements } = require('../../utils');
 
 /**
  * Check if `node` is a `visit(url)` expression
@@ -34,9 +34,10 @@ function transform(file, api) {
   if (replacements.length > 0) {
     makeAwait(j, replacements);
     dropAndThen(j, root);
-    addImportStatement(j, root, ['visit']);
+    addImportStatement(['visit']);
   }
 
+  writeImportStatements(j, root);
   return root.toSource({ quote: 'single' });
 }
 

--- a/lib/transforms/integration/attr.js
+++ b/lib/transforms/integration/attr.js
@@ -1,4 +1,4 @@
-const { createFindExpression, createPropExpression, isJQuerySelectExpression, addImportStatement } = require('../../utils');
+const { createFindExpression, createPropExpression, isJQuerySelectExpression, addImportStatement, writeImportStatements } = require('../../utils');
 
 /**
  * Creates a `find(selector).getAttribute(attr)` expression
@@ -70,9 +70,10 @@ function transform(file, api) {
     .replaceWith(({ node }) => createAttributeExpression(j, node.callee.object.arguments, node.arguments[0]));
 
   if (propReplacements.length > 0 || attrReplacements.length > 0) {
-    addImportStatement(j, root, ['find']);
+    addImportStatement(['find']);
   }
 
+  writeImportStatements(j, root);
   return root.toSource({ quote: 'single' });
 }
 

--- a/lib/transforms/integration/click.js
+++ b/lib/transforms/integration/click.js
@@ -1,4 +1,4 @@
-const { migrateSelector, createClickExpression, makeParentFunctionAsync, isJQuerySelectExpression, addImportStatement } = require('../../utils');
+const { migrateSelector, createClickExpression, makeParentFunctionAsync, isJQuerySelectExpression, addImportStatement, writeImportStatements } = require('../../utils');
 
 /**
  * Check if `node` is a `this.$(selector).click()` expression
@@ -36,9 +36,10 @@ function transform(file, api) {
     ;
 
   if (replacements.length > 0) {
-    addImportStatement(j, root, ['click']);
+    addImportStatement(['click']);
   }
 
+  writeImportStatements(j, root);
   return root.toSource({ quote: 'single' });
 }
 

--- a/lib/transforms/integration/focus.js
+++ b/lib/transforms/integration/focus.js
@@ -1,4 +1,4 @@
-const { createFocusExpression, makeParentFunctionAsync, isJQuerySelectExpression, addImportStatement } = require('../../utils');
+const { createFocusExpression, makeParentFunctionAsync, isJQuerySelectExpression, addImportStatement, writeImportStatements } = require('../../utils');
 
 /**
  * Check if `node` is a `this.$(selector).focus()` expression
@@ -36,9 +36,10 @@ function transform(file, api) {
     ;
 
   if (replacements.length > 0) {
-    addImportStatement(j, root, ['focus']);
+    addImportStatement(['focus']);
   }
 
+  writeImportStatements(j, root);
   return root.toSource({ quote: 'single' });
 }
 

--- a/lib/transforms/integration/get-value.js
+++ b/lib/transforms/integration/get-value.js
@@ -1,4 +1,4 @@
-const { createFindExpression, isJQuerySelectExpression, addImportStatement } = require('../../utils');
+const { createFindExpression, isJQuerySelectExpression, addImportStatement, writeImportStatements } = require('../../utils');
 
 /**
  * Creates a `find(selector).value` expression
@@ -49,9 +49,10 @@ function transform(file, api) {
     .replaceWith(({ node }) => createExpression(j, node.callee.object.arguments));
 
   if (replacements.length > 0) {
-    addImportStatement(j, root, ['find']);
+    addImportStatement(['find']);
   }
 
+  writeImportStatements(j, root);
   return root.toSource({quote: 'single'});
 }
 

--- a/lib/transforms/integration/has-class.js
+++ b/lib/transforms/integration/has-class.js
@@ -1,4 +1,4 @@
-const { createFindExpression, isJQuerySelectExpression, addImportStatement } = require('../../utils');
+const { createFindExpression, isJQuerySelectExpression, addImportStatement, writeImportStatements } = require('../../utils');
 
 /**
  * Creates a `find(selector).classList.contains(className)` expression
@@ -55,9 +55,10 @@ function transform(file, api) {
     .replaceWith(({ node }) => createExpression(j, node.callee.object.arguments, node.arguments[0]));
 
   if (replacements.length > 0) {
-    addImportStatement(j, root, ['find']);
+    addImportStatement(['find']);
   }
 
+  writeImportStatements(j, root);
   return root.toSource({ quote: 'single' });
 }
 

--- a/lib/transforms/integration/html.js
+++ b/lib/transforms/integration/html.js
@@ -1,4 +1,4 @@
-const { createFindExpression, isJQuerySelectExpression, addImportStatement } = require('../../utils');
+const { createFindExpression, isJQuerySelectExpression, addImportStatement, writeImportStatements } = require('../../utils');
 
 /**
  * Creates a `find(selector).innerHTML` expression
@@ -49,9 +49,10 @@ function transform(file, api) {
     .replaceWith(({ node }) => createExpression(j, node.callee.object.arguments));
 
   if (replacements.length > 0) {
-    addImportStatement(j, root, ['find']);
+    addImportStatement(['find']);
   }
 
+  writeImportStatements(j, root);
   return root.toSource({quote: 'single'});
 }
 

--- a/lib/transforms/integration/key-event.js
+++ b/lib/transforms/integration/key-event.js
@@ -1,4 +1,4 @@
-const { migrateSelector, makeParentFunctionAsync, isJQuerySelectExpression, addImportStatement } = require('../../utils');
+const { migrateSelector, makeParentFunctionAsync, isJQuerySelectExpression, addImportStatement, writeImportStatements } = require('../../utils');
 
 /**
  * Creates a `await keyEvent(selector, eventName, keyCode)` expression
@@ -60,9 +60,10 @@ function transform(file, api) {
     ;
 
   if (replacements.length > 0) {
-    addImportStatement(j, root, ['keyEvent']);
+    addImportStatement(['keyEvent']);
   }
 
+  writeImportStatements(j, root);
   return root.toSource({ quote: 'single' });
 }
 

--- a/lib/transforms/integration/length.js
+++ b/lib/transforms/integration/length.js
@@ -1,4 +1,4 @@
-const { createFindAllExpression, isJQuerySelectExpression, addImportStatement } = require('../../utils');
+const { createFindAllExpression, isJQuerySelectExpression, addImportStatement, writeImportStatements } = require('../../utils');
 
 /**
  * Creates a `findAll(selector).length` expression
@@ -47,8 +47,10 @@ function transform(file, api) {
     .replaceWith(({ node }) => createExpression(j, node.object.arguments));
 
   if (replacements.length > 0) {
-    addImportStatement(j, root, ['findAll']);
+    addImportStatement(['findAll']);
   }
+
+  writeImportStatements(j, root);
   return root.toSource({quote: 'single'});
 }
 

--- a/lib/transforms/integration/prop.js
+++ b/lib/transforms/integration/prop.js
@@ -1,4 +1,4 @@
-const { createPropExpression, isJQuerySelectExpression, addImportStatement } = require('../../utils');
+const { createPropExpression, isJQuerySelectExpression, addImportStatement, writeImportStatements } = require('../../utils');
 
 /**
  * Check if `node` is a `this.$(selector).prop('propName')` expression
@@ -37,9 +37,10 @@ function transform(file, api) {
     ;
 
   if (replacements.length > 0) {
-    addImportStatement(j, root, ['find']);
+    addImportStatement(['find']);
   }
 
+  writeImportStatements(j, root);
   return root.toSource({ quote: 'single' });
 }
 

--- a/lib/transforms/integration/set-value.js
+++ b/lib/transforms/integration/set-value.js
@@ -1,4 +1,4 @@
-const { migrateSelector, makeParentFunctionAsync, isJQuerySelectExpression, addImportStatement } = require('../../utils');
+const { migrateSelector, makeParentFunctionAsync, isJQuerySelectExpression, addImportStatement, writeImportStatements } = require('../../utils');
 
 /**
  * Creates a `await fillIn(selector, value)` expression
@@ -112,13 +112,14 @@ function transform(file, api) {
     .forEach((path) => makeParentFunctionAsync(j, path));
 
   if (replacements.length > 0) {
-    addImportStatement(j, root, ['fillIn']);
+    addImportStatement(['fillIn']);
   }
 
   if (changeReplacements.length > 0) {
-    addImportStatement(j, root, ['blur']);
+    addImportStatement(['blur']);
   }
 
+  writeImportStatements(j, root);
   return root.toSource({ quote: 'single' });
 }
 

--- a/lib/transforms/integration/text.js
+++ b/lib/transforms/integration/text.js
@@ -1,4 +1,4 @@
-const { createFindExpression, isJQuerySelectExpression, addImportStatement } = require('../../utils');
+const { createFindExpression, isJQuerySelectExpression, addImportStatement, writeImportStatements } = require('../../utils');
 
 /**
  * Creates a `find(selector).textContent` expression
@@ -48,9 +48,10 @@ function transform(file, api) {
     .replaceWith(({ node }) => createExpression(j, node.callee.object.arguments));
 
   if (replacements.length > 0) {
-    addImportStatement(j, root, ['find']);
+    addImportStatement(['find']);
   }
 
+  writeImportStatements(j, root);
   return root.toSource({quote: 'single'});
 }
 

--- a/lib/transforms/integration/trigger-shortcut.js
+++ b/lib/transforms/integration/trigger-shortcut.js
@@ -1,4 +1,4 @@
-const { makeParentFunctionAsync, createTriggerExpression, isJQuerySelectExpression, addImportStatement } = require('../../utils');
+const { makeParentFunctionAsync, createTriggerExpression, isJQuerySelectExpression, addImportStatement, writeImportStatements } = require('../../utils');
 
 const triggerShortcuts = [
   'change',
@@ -50,9 +50,10 @@ function transform(file, api) {
     ;
 
   if (replacements.length > 0) {
-    addImportStatement(j, root, ['triggerEvent']);
+    addImportStatement(['triggerEvent']);
   }
 
+  writeImportStatements(j, root);
   return root.toSource({ quote: 'single' });
 }
 

--- a/lib/transforms/integration/trigger.js
+++ b/lib/transforms/integration/trigger.js
@@ -1,4 +1,4 @@
-const { makeParentFunctionAsync, createTriggerExpression, createClickExpression, isJQuerySelectExpression, addImportStatement } = require('../../utils');
+const { makeParentFunctionAsync, createTriggerExpression, createClickExpression, isJQuerySelectExpression, addImportStatement, writeImportStatements } = require('../../utils');
 
 /**
  * Check if `node` is a `this.$(selector).trigger(eventName)` expression
@@ -46,9 +46,10 @@ function transform(file, api) {
     ;
 
   if (replacements.length > 0) {
-    addImportStatement(j, root, ['triggerEvent']);
+    addImportStatement(['triggerEvent']);
   }
 
+  writeImportStatements(j, root);
   return root.toSource({ quote: 'single' });
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,4 @@
 const jqExtensions = [
-  /:eq\(/,
   /:even/,
   /:odd/,
   /:contains\(/,
@@ -82,11 +81,21 @@ function isFindExpression(j, node) {
  * @param selector
  * @returns {*}
  */
-function migrateSelector(j, selector) {
+function migrateSelector(j, selector, fileRoot = null) {
   if (j.Literal.check(selector) && typeof selector.value === 'string') {
     let string = selector.value;
-    // @todo selector migrations could be added here
-    selector.value = string;
+
+    // When handling a special-case selector, return early.
+
+    // Transform tail-eq selector to a find all
+    if (/:eq\(\d+\)$/.test(string)) {
+      let [, query, eqIndex ] = string.match(/(.+?):eq\((\d+)\)$/);
+      selector.value = query;
+      if (fileRoot) {
+        addImportStatement(j, fileRoot, ['findAll']);
+      }
+      return createArraySubscriptExpression(j, createFindAllExpression(j, [ selector ]), +eqIndex);
+    }
   }
   return selector;
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -119,8 +119,25 @@ function createFindExpression(j, args) {
  * @param args  function arguments
  * @returns {*}
  */
-function createFindAllExpression(j, args) {
-  args = args.length > 0 ? args.map(s => migrateSelector(j, s)) : [j.literal('*')];
+function createFindAllExpression(j, args, fileRoot) {
+  args = args.length > 0 ? args.map(s => migrateSelector(j, s, fileRoot)) : [j.literal('*')];
+  let newArgs = args.length > 0 ? args.map(s => migrateSelector(j, s, fileRoot)) : [j.literal('*')];
+
+  // Avoid nesting findAll calls
+  let isFindAllCallExpression = args.length === 1
+    && j.CallExpression.check(args[0])
+    && j.Identifier.check(args[0].callee)
+    && args[0].callee.name === 'findAll';
+
+  let isFindAllMemberExpression = args.length === 1
+    && j.MemberExpression.check(args[0])
+    && j.Identifier.check(args[0].object.callee)
+    && args[0].object.callee.name === 'findAll';
+
+  if (isFindAllCallExpression || isFindAllMemberExpression) {
+    return args[0];
+  }
+
   return j.callExpression(j.identifier('findAll'), args);
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -94,8 +94,13 @@ function migrateSelector(j, selector) {
     if (/:eq\(\d+\)$/.test(string)) {
       let [, query, eqIndex ] = string.match(/(.+?):eq\((\d+)\)$/);
       selector.value = query;
-      addImportStatement(['findAll']);
-      return createArraySubscriptExpression(j, createFindAllExpression(j, [ selector ]), +eqIndex);
+      if (eqIndex === '0') {
+        // findAll('*')[0] === find('*')
+        return createFindExpression(j, [selector]);
+      } else {
+        addImportStatement(['findAll']);
+        return createArraySubscriptExpression(j, createFindAllExpression(j, [ selector ]), +eqIndex);
+      }
     }
   }
   return selector;
@@ -110,6 +115,17 @@ function migrateSelector(j, selector) {
  */
 function createFindExpression(j, args) {
   args = args.length > 0 ? args.map(s => migrateSelector(j, s)) : [j.literal('*')];
+
+  // Avoid nesting find calls
+  let isFindCallExpression = args.length === 1
+    && j.CallExpression.check(args[0])
+    && j.Identifier.check(args[0].callee)
+    && args[0].callee.name === 'find';
+
+  if (isFindCallExpression) {
+    return args[0];
+  }
+
   return j.callExpression(j.identifier('find'), args);
 }
 
@@ -122,7 +138,6 @@ function createFindExpression(j, args) {
  */
 function createFindAllExpression(j, args, fileRoot) {
   args = args.length > 0 ? args.map(s => migrateSelector(j, s, fileRoot)) : [j.literal('*')];
-  let newArgs = args.length > 0 ? args.map(s => migrateSelector(j, s, fileRoot)) : [j.literal('*')];
 
   // Avoid nesting findAll calls
   let isFindAllCallExpression = args.length === 1
@@ -149,10 +164,22 @@ function createFindAllExpression(j, args, fileRoot) {
  * @returns {*}
  */
 function createClickExpression(j, args) {
+  args = args.map(s => migrateSelector(j, s));
+
+  // Collapse inner find call
+  let isFindCallExpression = args.length === 1
+    && j.CallExpression.check(args[0])
+    && j.Identifier.check(args[0].callee)
+    && args[0].callee.name === 'find';
+
+  if (isFindCallExpression) {
+    args[0] = args[0].arguments[0];
+  }
+
   return j.awaitExpression(
     j.callExpression(
       j.identifier('click'),
-      args.map(s => migrateSelector(j, s))
+      args
     )
   );
 }
@@ -241,7 +268,6 @@ function addImportStatement(imports) {
  * @param root
  */
 function writeImportStatements(j, root) {
-  console.log('WRITING IMPORT: ', _statementsToImport);
   if (_statementsToImport.size > 0) {
     let body = root.get().value.program.body;
     let importStatement = root.find(j.ImportDeclaration, {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -24,6 +24,9 @@ const jqExtensions = [
   /:visible/
 ];
 
+// Collects all statements that need to be imported. Gets flushed when writeImportStatemtns is called.
+let _statementsToImport = new Set();
+
 /**
  * Check of the CSS selector string contains some jQuery specific parts
  *
@@ -81,7 +84,7 @@ function isFindExpression(j, node) {
  * @param selector
  * @returns {*}
  */
-function migrateSelector(j, selector, fileRoot = null) {
+function migrateSelector(j, selector) {
   if (j.Literal.check(selector) && typeof selector.value === 'string') {
     let string = selector.value;
 
@@ -91,9 +94,7 @@ function migrateSelector(j, selector, fileRoot = null) {
     if (/:eq\(\d+\)$/.test(string)) {
       let [, query, eqIndex ] = string.match(/(.+?):eq\((\d+)\)$/);
       selector.value = query;
-      if (fileRoot) {
-        addImportStatement(j, fileRoot, ['findAll']);
-      }
+      addImportStatement(['findAll']);
       return createArraySubscriptExpression(j, createFindAllExpression(j, [ selector ]), +eqIndex);
     }
   }
@@ -222,30 +223,46 @@ function createBlurExpression(j, selector) {
 }
 
 /**
- * Adds (one or more) named imports to an (existing or to be created) `import { namedImport } from 'ember-native-dom-helpers';
+ * Adds (one or more) named imports to a private import statement collection.
+ * To write the import statements to a file, use writeImportStatements.
+ *
+ * @param j
+ * @param {array} imports
+ */
+function addImportStatement(imports) {
+  imports.forEach(method => _statementsToImport.add(method));
+}
+
+/**
+ * Adds all collected named imports to an (existing or to be created) `import { namedImport } from 'ember-native-dom-helpers';
+ * To add named imports to the collection, use addImportStatement
  *
  * @param j
  * @param root
- * @param {array} imports
  */
-function addImportStatement(j, root, imports) {
-  let body = root.get().value.program.body;
-  let importStatement = root.find(j.ImportDeclaration, {
-    source: { value: 'ember-native-dom-helpers' }
-  });
-
-  if (importStatement.length === 0) {
-    importStatement = createImportStatement(j, 'ember-native-dom-helpers', 'default', imports);
-    body.unshift(importStatement);
-  } else {
-    let existingSpecifiers = importStatement.get("specifiers");
-
-    imports.forEach(name => {
-      if (existingSpecifiers.filter(exSp => exSp.value.imported.name === name).length === 0) {
-        existingSpecifiers.push(j.importSpecifier(j.identifier(name)));
-      }
+function writeImportStatements(j, root) {
+  console.log('WRITING IMPORT: ', _statementsToImport);
+  if (_statementsToImport.size > 0) {
+    let body = root.get().value.program.body;
+    let importStatement = root.find(j.ImportDeclaration, {
+      source: { value: 'ember-native-dom-helpers' }
     });
+
+    if (importStatement.length === 0) {
+      importStatement = createImportStatement(j, 'ember-native-dom-helpers', 'default', Array.from(_statementsToImport));
+      body.unshift(importStatement);
+    } else {
+      let existingSpecifiers = importStatement.get("specifiers");
+
+      _statementsToImport.forEach(name => {
+        if (existingSpecifiers.filter(exSp => exSp.value.imported.name === name).length === 0) {
+          existingSpecifiers.push(j.importSpecifier(j.identifier(name)));
+        }
+      });
+    }
   }
+
+  _statementsToImport = new Set();
 }
 
 /**
@@ -380,6 +397,7 @@ module.exports = {
   createFocusExpression,
   createBlurExpression,
   addImportStatement,
+  writeImportStatements,
   createImportStatement,
   makeParentFunctionAsync,
   migrateSelector,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -170,6 +170,10 @@ function createPropExpression(j, findArgs, prop) {
   );
 }
 
+function createArraySubscriptExpression(j, expression, index) {
+  return j.memberExpression(expression, j.literal(index));
+}
+
 /**
  * Create `await focus(selector)` expression
  * @param j
@@ -355,6 +359,7 @@ module.exports = {
   createClickExpression,
   createTriggerExpression,
   createPropExpression,
+  createArraySubscriptExpression,
   createFocusExpression,
   createBlurExpression,
   addImportStatement,

--- a/test/acceptance/expected-output/click.js
+++ b/test/acceptance/expected-output/click.js
@@ -1,4 +1,4 @@
-import { click, currentURL, visit } from 'ember-native-dom-helpers';
+import { click, currentURL, findAll, visit } from 'ember-native-dom-helpers';
 import { test } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 
@@ -8,5 +8,6 @@ test('visiting /foo', async function(assert) {
   await visit('/foo');
 
   await click('#bar');
+  await click(findAll('.baz a')[12]);
   assert.equal(currentURL(), '/foo');
 });

--- a/test/acceptance/expected-output/fill-in.js
+++ b/test/acceptance/expected-output/fill-in.js
@@ -1,4 +1,4 @@
-import { fillIn, currentURL, visit } from 'ember-native-dom-helpers';
+import { fillIn, currentURL, findAll, visit } from 'ember-native-dom-helpers';
 import { test } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 
@@ -8,5 +8,6 @@ test('visiting /foo', async function(assert) {
   await visit('/foo');
 
   await fillIn('#bar', 'baz');
+  await fillIn(findAll('#qux input')[5], 'qaaz');
   assert.equal(currentURL(), '/foo');
 });

--- a/test/acceptance/input/click.js
+++ b/test/acceptance/input/click.js
@@ -7,6 +7,7 @@ test('visiting /foo', function(assert) {
   visit('/foo');
 
   click('#bar');
+  click('.baz a:eq(12)');
   andThen(function() {
     assert.equal(currentURL(), '/foo');
   });

--- a/test/acceptance/input/fill-in.js
+++ b/test/acceptance/input/fill-in.js
@@ -7,6 +7,7 @@ test('visiting /foo', function(assert) {
   visit('/foo');
 
   fillIn('#bar', 'baz');
+  fillIn('#qux input:eq(5)', 'qaaz');
   andThen(function() {
     assert.equal(currentURL(), '/foo');
   });

--- a/test/integration/expected-output/click.js
+++ b/test/integration/expected-output/click.js
@@ -1,4 +1,4 @@
-import { click } from 'ember-native-dom-helpers';
+import { findAll, click } from 'ember-native-dom-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -10,5 +10,6 @@ test('it renders', async function(assert) {
   this.render(hbs`{{foo-bar}}`);
 
   await click('.foo');
+  await click(findAll('.foo .bar')[3]);
   assert.ok(true);
 });

--- a/test/integration/expected-output/click.js
+++ b/test/integration/expected-output/click.js
@@ -10,6 +10,7 @@ test('it renders', async function(assert) {
   this.render(hbs`{{foo-bar}}`);
 
   await click('.foo');
+  await click('.baz a');
   await click(findAll('.foo .bar')[3]);
   assert.ok(true);
 });

--- a/test/integration/expected-output/jq-extensions.js
+++ b/test/integration/expected-output/jq-extensions.js
@@ -33,7 +33,8 @@ test('it renders', function(assert) {
   assert.ok(this.$('.foo:text').length);
   assert.ok(this.$('.foo:visible').length);
 
-  assert.ok(findAll('.foo')[0].length);
+  assert.ok(findAll(find('.foo')).length);
+  assert.ok(findAll('.foo')[1].length);
   assert.ok(findAll('.foo:first-child').length);
   assert.ok(findAll('.foo:last-child').length);
 });

--- a/test/integration/expected-output/jq-extensions.js
+++ b/test/integration/expected-output/jq-extensions.js
@@ -9,7 +9,6 @@ moduleForComponent('foo-bar', 'Integration | Component | foo bar', {
 test('it renders', function(assert) {
   this.render(hbs`{{foo-bar}}`);
 
-  assert.ok(this.$('.foo:eq(0)').length);
   assert.ok(this.$('.foo:even').length);
   assert.ok(this.$('.foo:odd').length);
   assert.ok(this.$('.foo:contains(foo)').length);
@@ -34,6 +33,7 @@ test('it renders', function(assert) {
   assert.ok(this.$('.foo:text').length);
   assert.ok(this.$('.foo:visible').length);
 
+  assert.ok(findAll('.foo')[0].length);
   assert.ok(findAll('.foo:first-child').length);
   assert.ok(findAll('.foo:last-child').length);
 });

--- a/test/integration/input/click.js
+++ b/test/integration/input/click.js
@@ -9,6 +9,7 @@ test('it renders', function(assert) {
   this.render(hbs`{{foo-bar}}`);
 
   this.$('.foo').click();
+  this.$('.baz a:eq(0)').click();
   this.$('.foo .bar:eq(3)').click();
   assert.ok(true);
 });

--- a/test/integration/input/click.js
+++ b/test/integration/input/click.js
@@ -9,5 +9,6 @@ test('it renders', function(assert) {
   this.render(hbs`{{foo-bar}}`);
 
   this.$('.foo').click();
+  this.$('.foo .bar:eq(3)').click();
   assert.ok(true);
 });

--- a/test/integration/input/jq-extensions.js
+++ b/test/integration/input/jq-extensions.js
@@ -8,7 +8,6 @@ moduleForComponent('foo-bar', 'Integration | Component | foo bar', {
 test('it renders', function(assert) {
   this.render(hbs`{{foo-bar}}`);
 
-  assert.ok(this.$('.foo:eq(0)').length);
   assert.ok(this.$('.foo:even').length);
   assert.ok(this.$('.foo:odd').length);
   assert.ok(this.$('.foo:contains(foo)').length);
@@ -33,6 +32,7 @@ test('it renders', function(assert) {
   assert.ok(this.$('.foo:text').length);
   assert.ok(this.$('.foo:visible').length);
 
+  assert.ok(this.$('.foo:eq(0)').length);
   assert.ok(this.$('.foo:first-child').length);
   assert.ok(this.$('.foo:last-child').length);
 });

--- a/test/integration/input/jq-extensions.js
+++ b/test/integration/input/jq-extensions.js
@@ -33,6 +33,7 @@ test('it renders', function(assert) {
   assert.ok(this.$('.foo:visible').length);
 
   assert.ok(this.$('.foo:eq(0)').length);
+  assert.ok(this.$('.foo:eq(1)').length);
   assert.ok(this.$('.foo:first-child').length);
   assert.ok(this.$('.foo:last-child').length);
 });


### PR DESCRIPTION
I had a bunch of these in my tests and I didn't want to deal with them by hand.

To be clear, this _only_ handles the case where the `:eq` directive appears at the end of the selector. No support for `:eq` in the middle, no support for `:eq` in a template string, and no support for `:eq` in a variable that is later passed to a method.

Still though, this was useful for me and probably others.