### PR TITLE
Ensure `andThen(() => {})` is transformed.

### DIFF
--- a/__testfixtures__/acceptance/visit.input.js
+++ b/__testfixtures__/acceptance/visit.input.js
@@ -10,6 +10,13 @@ test('visiting /foo', function(assert) {
   });
 });
 
+test('visiting /bar', function(assert) {
+  visit('/bar');
+  andThen(() => {
+    assert.equal(currentURL(), '/bar');
+  });
+});
+
 test('visiting /bar', async function(assert) {
   await visit('/bar');
   assert.equal(currentURL(), '/bar');

--- a/__testfixtures__/acceptance/visit.output.js
+++ b/__testfixtures__/acceptance/visit.output.js
@@ -13,3 +13,8 @@ test('visiting /bar', async function(assert) {
   await visit('/bar');
   assert.equal(currentURL(), '/bar');
 });
+
+test('visiting /bar', async function(assert) {
+  await visit('/bar');
+  assert.equal(currentURL(), '/bar');
+});

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -384,13 +384,7 @@ function makeParentFunctionAsync(j, path) {
  */
 function dropAndThen(j, root) {
   let replacements = root
-    .find(j.CallExpression)
-    .filter(({ node }) => {
-      return j.Identifier.check(node.callee)
-        && node.callee.name === 'andThen'
-        && node.arguments.length === 1
-        && j.FunctionExpression.check(node.arguments[0])
-    })
+    .find(j.CallExpression, { callee: { name: 'andThen' } })
     .map((path) => path.parent)
     .replaceWith(({ node }) => {
       return node.expression.arguments[0].body.body;


### PR DESCRIPTION
Fixes #25