### PR TITLE
Updating `migrateSelector` to support selectors as variables

### DIFF
--- a/__testfixtures__/integration/all.output.js
+++ b/__testfixtures__/integration/all.output.js
@@ -25,8 +25,8 @@ test('it renders again', function(assert) {
   this.render(hbs`{{foo-bar}}`);
 
   let selector = '.foo input';
-  assert.equal(findAll(selector).length, 1);
-  assert.equal(find(selector).value, 'foo');
+  assert.equal(findAll(this.$(selector)[0]).length, 1);
+  assert.equal(find(this.$(selector)[0]).value, 'foo');
   assert.ok(find('.foo').classList.contains('selected'));
 });
 

--- a/__testfixtures__/integration/jq-extensions.input.js
+++ b/__testfixtures__/integration/jq-extensions.input.js
@@ -36,13 +36,13 @@ test('it renders', function(assert) {
   assert.ok(this.$('.foo:submit').length);
   assert.ok(this.$('.foo:text').length);
   assert.ok(this.$('.foo:visible').length);
-  assert.ok(this.$(JQEXTENSION_SELECTOR_AS_LOCAL_CONST).length);
-  assert.ok(this.$(ANY_SELECTOR_AS_IMPORTED_CONST).length);
 
   assert.ok(this.$('.foo:eq(0)').length);
   assert.ok(this.$('.foo:eq(1)').length);
   assert.ok(this.$('.foo:first-child').length);
   assert.ok(this.$('.foo:last-child').length);
+  assert.ok(this.$(JQEXTENSION_SELECTOR_AS_LOCAL_CONST).length);
+  assert.ok(this.$(ANY_SELECTOR_AS_IMPORTED_CONST).length);
   assert.ok(this.$(NORMAL_SELECTOR).length);
   assert.ok(this.$(NORMAL_PSEUDO_SELECTOR).length);
 });

--- a/__testfixtures__/integration/jq-extensions.output.js
+++ b/__testfixtures__/integration/jq-extensions.output.js
@@ -37,13 +37,13 @@ test('it renders', function(assert) {
   assert.ok(this.$('.foo:submit').length);
   assert.ok(this.$('.foo:text').length);
   assert.ok(this.$('.foo:visible').length);
-  assert.ok(this.$(JQEXTENSION_SELECTOR_AS_LOCAL_CONST).length);
-  assert.ok(this.$(ANY_SELECTOR_AS_IMPORTED_CONST).length);  
 
   assert.ok(findAll(find('.foo')).length);
   assert.ok(findAll('.foo')[1].length);
   assert.ok(findAll('.foo:first-child').length);
   assert.ok(findAll('.foo:last-child').length);
-  assert.ok(findAll(NORMAL_SELECTOR).length);
-  assert.ok(findAll(NORMAL_PSEUDO_SELECTOR).length);
+  assert.ok(findAll(this.$(JQEXTENSION_SELECTOR_AS_LOCAL_CONST)[0]).length);
+  assert.ok(findAll(this.$(ANY_SELECTOR_AS_IMPORTED_CONST)[0]).length);
+  assert.ok(findAll(this.$(NORMAL_SELECTOR)[0]).length);
+  assert.ok(findAll(this.$(NORMAL_PSEUDO_SELECTOR)[0]).length);
 });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -102,7 +102,11 @@ function migrateSelector(j, selector) {
         return createArraySubscriptExpression(j, createFindAllExpression(j, [ selector ]), +eqIndex);
       }
     }
+  } else if (j.Identifier.check(selector)) {
+    // reference the selector as an identifier with array index eg. this.$(SELECTOR)[0] 
+    return createArraySubscriptExpression(j, j.callExpression(j.memberExpression(j.thisExpression(), j.identifier('$')), [selector]), 0);
   }
+
   return selector;
 }
 


### PR DESCRIPTION
Adding a failing test for #27 