### PR TITLE
Error when running integration transforms

### DIFF
--- a/lib/transforms/integration/set-value.js
+++ b/lib/transforms/integration/set-value.js
@@ -40,7 +40,7 @@ function isJQueryExpression(j, path) {
   let node = path.node;
   return j.CallExpression.check(node)
     && j.MemberExpression.check(node.callee)
-    && isJQuerySelectExpression(j, node.callee.object)
+    && isJQuerySelectExpression(j, node.callee.object, path)
     && j.Identifier.check(node.callee.property)
     && node.callee.property.name === 'val'
     && node.arguments.length > 0


### PR DESCRIPTION
An error was occurring in the set-value.js transform for integration tests. Adding the path to `isJQuerySelectExpression` fixed this.