### PR TITLE
Fixing issue with unwrapping andThen in acceptance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .idea
+.vscode/

--- a/__testfixtures__/acceptance/nested-in-and-then.input.js
+++ b/__testfixtures__/acceptance/nested-in-and-then.input.js
@@ -8,6 +8,10 @@ test('visiting /twiddles', function(assert) {
     click('.foo');
   });
 
+  andThen(() => {
+    click('.foo');
+  });
+
   andThen(function() {
     andThen(function() {
       andThen(function() {
@@ -15,4 +19,10 @@ test('visiting /twiddles', function(assert) {
       });
     });
   });
+
+  andThen(() => {
+    assert.ok(true)
+  });
+
+  andThen(() => assert.ok(true));
 });

--- a/__testfixtures__/acceptance/nested-in-and-then.input.js
+++ b/__testfixtures__/acceptance/nested-in-and-then.input.js
@@ -21,7 +21,7 @@ test('visiting /twiddles', function(assert) {
   });
 
   andThen(() => {
-    assert.ok(true)
+    assert.ok(true);
   });
 
   andThen(() => assert.ok(true));

--- a/__testfixtures__/acceptance/nested-in-and-then.output.js
+++ b/__testfixtures__/acceptance/nested-in-and-then.output.js
@@ -8,4 +8,10 @@ test('visiting /twiddles', async function(assert) {
   await click('.foo');
 
   await click('.foo');
+
+  await click('.foo');
+
+  assert.ok(true);
+
+  assert.ok(true);
 });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -415,7 +415,13 @@ function dropAndThen(j, root) {
     .find(j.CallExpression, { callee: { name: 'andThen' } })
     .map((path) => path.parent)
     .replaceWith(({ node }) => {
-      return node.expression.arguments[0].body.body;
+      let body = node.expression.arguments[0].body;
+
+      if (j.CallExpression.check(body)) {
+        return j.expressionStatement(body);
+      }
+
+      return body.body;
     });
 
   if (replacements.length > 0) {


### PR DESCRIPTION
When unwrapping `andThen`, arrow functions with no block expression were being erroneously removed. This PR adds a test, and fixes the issue.

There's one issue remaining: I don't know how to append a semicolon to the end of the unwrapped arrow function call statement. Do you guys know, @simonihmig @rwjblue?