### PR TITLE
Add transform for .first() and .get()

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ This addon will perform the following transformations suitable for integration t
 | `this.$('.foo').html()`                              | `find('.foo').innerHTML`                                              | `html.js`      |
 | `this.$('.foo').html('foo')`                         | `find('.foo').innerHTML = 'foo'`                                      | `html.js`      |
 | `this.$('.foo').each((index, elem) => {...})`        | `findAll('.foo').forEach((elem, index) => {...})`                     | `each.js`      |
+| `this.$('.foo').first()`                             | `findAll('.foo')[0]`                                                  | `first-and-get.js`     |
+| `this.$('.foo').get(3)`                              | `findAll('.foo')[3]`                                                  | `first-and-get.js`     |
 
 
 If you want to run only selected transforms on your code, you can just the needed transform:
@@ -83,6 +85,8 @@ These transformations are available for acceptance tests:
 | `find('.foo').html()`                                | `find('.foo').innerHTML`                                              | `html.js`      |
 | `find('.foo').html('foo')`                           | `find('.foo').innerHTML = 'foo'`                                      | `html.js`      |
 | `find('.foo').each((index, elem) => {...})`          | `findAll('.foo').forEach((elem, index) => {...})`                     | `each.js`      |
+| `find('.foo').first()`                               | `findAll('.foo')[0]`                                                  | `first-and-get.js`     |
+| `find('.foo').get(3)`                               | `findAll('.foo')[3]`                                                  | `first-and-get.js`     |
 
 If you want to run only selected transforms on your code, you can just the needed transform:
 

--- a/__testfixtures__/acceptance/first-and-get.input.js
+++ b/__testfixtures__/acceptance/first-and-get.input.js
@@ -1,0 +1,16 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('first-and-get');
+
+test('transforms first() correctly', function(assert) {
+  assert.ok(find('.foo bar').first());
+
+  const otherFirst = someOtherObj.first();
+});
+
+test('transforms get() correctly', function(assert) {
+  assert.ok(find('.foo bar').get(3));
+
+  const otherGet = someOtherObj.get(1);
+});

--- a/__testfixtures__/acceptance/first-and-get.output.js
+++ b/__testfixtures__/acceptance/first-and-get.output.js
@@ -1,0 +1,17 @@
+import { findAll } from 'ember-native-dom-helpers';
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('first-and-get');
+
+test('transforms first() correctly', function(assert) {
+  assert.ok(findAll('.foo bar')[0]);
+
+  const otherFirst = someOtherObj.first();
+});
+
+test('transforms get() correctly', function(assert) {
+  assert.ok(findAll('.foo bar')[3]);
+
+  const otherGet = someOtherObj.get(1);
+});

--- a/__testfixtures__/integration/first-and-get.input.js
+++ b/__testfixtures__/integration/first-and-get.input.js
@@ -1,0 +1,20 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('foo-bar', 'Integration | Component | foo bar', {
+  integration: true
+});
+
+test('transforms first() correctly', function(assert) {
+  this.render(hbs`{{foo-bar}}`);
+
+  assert.ok(this.$('.foo').first());
+
+  const otherFirst = someOtherObj.first();
+});
+
+test('transforms get() correctly', function(assert) {
+  assert.ok(this.$('.foo').get(1));
+
+  const otherGet = someOtherObj.get(1);
+});

--- a/__testfixtures__/integration/first-and-get.output.js
+++ b/__testfixtures__/integration/first-and-get.output.js
@@ -1,0 +1,21 @@
+import { findAll } from 'ember-native-dom-helpers';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('foo-bar', 'Integration | Component | foo bar', {
+  integration: true
+});
+
+test('transforms first() correctly', function(assert) {
+  this.render(hbs`{{foo-bar}}`);
+
+  assert.ok(findAll('.foo')[0]);
+
+  const otherFirst = someOtherObj.first();
+});
+
+test('transforms get() correctly', function(assert) {
+  assert.ok(findAll('.foo')[1]);
+
+  const otherGet = someOtherObj.get(1);
+});

--- a/lib/transforms/acceptance/first-and-get.js
+++ b/lib/transforms/acceptance/first-and-get.js
@@ -3,29 +3,26 @@ const {
   isFindExpression,
   addImportStatement,
   writeImportStatements,
-  transformEachsCallbackArgs
 } = require('../../utils');
 
 /**
- * Creates a `findAll(selector).forEach()` expression
+ * Creates a `findAll(selector)[0]` expression
  *
  * @param j
  * @param findArgs
- * @param eachCallback
+ * @param indexArg
  * @returns {*}
  */
-function createExpression(j, findArgs, eachCallback) {
-  const transformedCallback = transformEachsCallbackArgs(eachCallback);
-  return j.callExpression(
-    j.memberExpression(
-      createFindAllExpression(j, findArgs),
-      j.identifier('forEach')
-    ), transformedCallback
+function createExpression(j, findArgs, indexArg) {
+  const index = indexArg[0] && indexArg[0].value || 0;
+  return j.memberExpression(
+    createFindAllExpression(j, findArgs),
+    j.literal(index)
   );
 }
 
 /**
- * Check if `node` is a `find(selector).each()` expression
+ * Check if `node` is a `find(selector).first()` or `find(selector).get(0)` expression
  *
  * @param j
  * @param node
@@ -36,11 +33,12 @@ function isJQueryExpression(j, node) {
     && j.MemberExpression.check(node.callee)
     && isFindExpression(j, node.callee.object)
     && j.Identifier.check(node.callee.property)
-    && node.callee.property.name === 'each'
+    && (node.callee.property.name === 'first' ||
+      node.callee.property.name === 'get')
 }
 
 /**
- * Transform `find(selector).each()` to `findAll(selector).forEach()`
+ * Transform `find(selector).first()/get(0)` to `findAll(selector)[0]`
  *
  * @param file
  * @param api

--- a/lib/transforms/integration/first-and-get.js
+++ b/lib/transforms/integration/first-and-get.js
@@ -1,46 +1,45 @@
 const {
   createFindAllExpression,
-  isFindExpression,
+  isJQuerySelectExpression,
   addImportStatement,
   writeImportStatements,
-  transformEachsCallbackArgs
 } = require('../../utils');
 
 /**
- * Creates a `findAll(selector).forEach()` expression
+ * Creates a `findAll(selector)[0]` expression
  *
  * @param j
  * @param findArgs
- * @param eachCallback
+ * @param indexArg
  * @returns {*}
  */
-function createExpression(j, findArgs, eachCallback) {
-  const transformedCallback = transformEachsCallbackArgs(eachCallback);
-  return j.callExpression(
-    j.memberExpression(
-      createFindAllExpression(j, findArgs),
-      j.identifier('forEach')
-    ), transformedCallback
+function createExpression(j, findArgs, indexArg) {
+  const index = indexArg[0] && indexArg[0].value || 0;
+  return j.memberExpression(
+    createFindAllExpression(j, findArgs),
+    j.literal(index)
   );
 }
 
 /**
- * Check if `node` is a `find(selector).each()` expression
+ * Check if `node` is a `this.$(selector).first()` or `this.$(selector).get(0)` expression
  *
  * @param j
  * @param node
  * @returns {*|boolean}
  */
-function isJQueryExpression(j, node) {
+function isJQueryExpression(j, path) {
+  let node = path.node;
   return j.CallExpression.check(node)
     && j.MemberExpression.check(node.callee)
-    && isFindExpression(j, node.callee.object)
+    && isJQuerySelectExpression(j, node.callee.object, path)
     && j.Identifier.check(node.callee.property)
-    && node.callee.property.name === 'each'
+    && (node.callee.property.name === 'first' ||
+      node.callee.property.name === 'get');
 }
 
 /**
- * Transform `find(selector).each()` to `findAll(selector).forEach()`
+ * Transforms `this.$(selector).first()` or `this.$(selector).get(0)` to `findAll(selector)[0]`
  *
  * @param file
  * @param api
@@ -54,7 +53,7 @@ function transform(file, api) {
 
   let replacements = root
     .find(j.CallExpression)
-    .filter(({ node }) => isJQueryExpression(j, node))
+    .filter((path) => isJQueryExpression(j, path))
     .replaceWith(({ node }) => createExpression(j, node.callee.object.arguments, node.arguments));
 
   if (replacements.length > 0) {


### PR DESCRIPTION
The code for replacing `find(...).first()` and `find(...).get(x)` is almost the same, so decided to combine them into one rule. 

Adds a `first()` and `get()` transform for Acceptance and Integration
Adds tests for both
Updates README to include both transforms