### PR TITLE
Add transform for last()

### DIFF
--- a/__testfixtures__/acceptance/last.input.js
+++ b/__testfixtures__/acceptance/last.input.js
@@ -1,0 +1,10 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('last');
+
+test('transforms last() correctly', function(assert) {
+  assert.ok(find('.foo bar').last());
+
+  const otherLast = someOtherObj.last();
+});

--- a/__testfixtures__/acceptance/last.output.js
+++ b/__testfixtures__/acceptance/last.output.js
@@ -1,0 +1,11 @@
+import { findAll } from 'ember-native-dom-helpers';
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('last');
+
+test('transforms last() correctly', function(assert) {
+  assert.ok(findAll('.foo bar').slice(-1)[0]);
+
+  const otherLast = someOtherObj.last();
+});

--- a/__testfixtures__/integration/last.input.js
+++ b/__testfixtures__/integration/last.input.js
@@ -1,0 +1,14 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('foo-bar', 'Integration | Component | foo bar', {
+  integration: true
+});
+
+test('transforms last() correctly', function(assert) {
+  this.render(hbs`{{foo-bar}}`);
+
+  assert.ok(this.$('.foo').last());
+
+  const otherLast = someOtherObj.last();
+});

--- a/__testfixtures__/integration/last.output.js
+++ b/__testfixtures__/integration/last.output.js
@@ -1,0 +1,15 @@
+import { findAll } from 'ember-native-dom-helpers';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('foo-bar', 'Integration | Component | foo bar', {
+  integration: true
+});
+
+test('transforms last() correctly', function(assert) {
+  this.render(hbs`{{foo-bar}}`);
+
+  assert.ok(findAll('.foo').slice(-1)[0]);
+
+  const otherLast = someOtherObj.last();
+});

--- a/lib/transforms/acceptance/last.js
+++ b/lib/transforms/acceptance/last.js
@@ -1,0 +1,67 @@
+const {
+  createFindAllExpression,
+  isFindExpression,
+  addImportStatement,
+  writeImportStatements,
+} = require('../../utils');
+
+/**
+ * Creates a `findAll(selector).slice(-1)[0]` expression
+ *
+ * @param j
+ * @param findArgs
+ * @returns {*}
+ */
+function createExpression(j, findArgs) {
+  return j.memberExpression(
+    j.callExpression(
+      j.memberExpression(
+        createFindAllExpression(j, findArgs),
+        j.identifier('slice')
+      ), [j.identifier('-1')]
+    ), j.literal(0)
+  );
+}
+
+/**
+ * Check if `node` is a `find(selector).last()` expression
+ *
+ * @param j
+ * @param node
+ * @returns {*|boolean}
+ */
+function isJQueryExpression(j, node) {
+  return j.CallExpression.check(node)
+    && j.MemberExpression.check(node.callee)
+    && isFindExpression(j, node.callee.object)
+    && j.Identifier.check(node.callee.property)
+    && node.callee.property.name === 'last'
+}
+
+/**
+ * Transform `find(selector).last()` to `findAll(selector).slice(-1)[0]`
+ *
+ * @param file
+ * @param api
+ * @returns {*|string}
+ */
+function transform(file, api) {
+  let source = file.source;
+  let j = api.jscodeshift;
+
+  let root = j(source);
+
+  let replacements = root
+    .find(j.CallExpression)
+    .filter(({ node }) => isJQueryExpression(j, node))
+    .replaceWith(({ node }) => createExpression(j, node.callee.object.arguments));
+
+  if (replacements.length > 0) {
+    addImportStatement(['findAll']);
+  }
+
+  writeImportStatements(j, root);
+  return root.toSource({ quote: 'single' });
+}
+
+module.exports = transform;

--- a/lib/transforms/integration/last.js
+++ b/lib/transforms/integration/last.js
@@ -1,0 +1,68 @@
+const {
+  createFindAllExpression,
+  isJQuerySelectExpression,
+  addImportStatement,
+  writeImportStatements,
+} = require('../../utils');
+
+/**
+ * Creates a `findAll(selector).slice(-1)[0]` expression
+ *
+ * @param j
+ * @param findArgs
+ * @returns {*}
+ */
+function createExpression(j, findArgs) {
+  return j.memberExpression(
+    j.callExpression(
+      j.memberExpression(
+        createFindAllExpression(j, findArgs),
+        j.identifier('slice')
+      ), [j.identifier('-1')]
+    ), j.literal(0)
+  );
+}
+
+/**
+ * Check if `node` is a `this.$(selector).last()` expression
+ *
+ * @param j
+ * @param node
+ * @returns {*|boolean}
+ */
+function isJQueryExpression(j, path) {
+  let node = path.node;
+  return j.CallExpression.check(node)
+    && j.MemberExpression.check(node.callee)
+    && isJQuerySelectExpression(j, node.callee.object, path)
+    && j.Identifier.check(node.callee.property)
+    && node.callee.property.name === 'last';
+}
+
+/**
+ * Transforms `this.$(selector).last()` to `findAll(selector).slice(-1)[0]`
+ *
+ * @param file
+ * @param api
+ * @returns {*|string}
+ */
+function transform(file, api) {
+  let source = file.source;
+  let j = api.jscodeshift;
+
+  let root = j(source);
+
+  let replacements = root
+    .find(j.CallExpression)
+    .filter((path) => isJQueryExpression(j, path))
+    .replaceWith(({ node }) => createExpression(j, node.callee.object.arguments));
+
+  if (replacements.length > 0) {
+    addImportStatement(['findAll']);
+  }
+
+  writeImportStatements(j, root);
+  return root.toSource({ quote: 'single' });
+}
+
+module.exports = transform;


### PR DESCRIPTION
What this transform does:
```find(...).last() ===> findAll(...).slice(-1)[0]```

Ideally one would use `array[array.length - 1]`, but I didn't want to start adding variables to people's tests. Luckily, the `slice` method is about [10x faster](https://jsperf.com/get-last-item-from-array-nf/1) than `$(...).last()`

- Adds a `last()` transform for Acceptance and Integration
- Adds tests for both
- Updates README to include `last` transform