### PR TITLE
.get() transform should support negative indexes

### DIFF
--- a/__testfixtures__/acceptance/get.input.js
+++ b/__testfixtures__/acceptance/get.input.js
@@ -5,6 +5,8 @@ moduleForAcceptance('get');
 
 test('transforms get() correctly', function(assert) {
   assert.ok(find('.foo bar').get(3));
+  assert.ok(find('.foo bar').get(-1));
+  assert.ok(find('.foo bar').get(-3));
 
   const otherGet = someOtherObj.get(1);
 });

--- a/__testfixtures__/acceptance/get.output.js
+++ b/__testfixtures__/acceptance/get.output.js
@@ -6,6 +6,8 @@ moduleForAcceptance('get');
 
 test('transforms get() correctly', function(assert) {
   assert.ok(findAll('.foo bar')[3]);
+  assert.ok(findAll('.foo bar').slice(-1)[0]);
+  assert.ok(findAll('.foo bar').slice(-3)[0]);
 
   const otherGet = someOtherObj.get(1);
 });

--- a/__testfixtures__/integration/get.input.js
+++ b/__testfixtures__/integration/get.input.js
@@ -7,6 +7,7 @@ moduleForComponent('foo-bar', 'Integration | Component | foo bar', {
 
 test('transforms get() correctly', function(assert) {
   assert.ok(this.$('.foo').get(1));
+  assert.ok(this.$('.foo').get(-2));
 
   const otherGet = someOtherObj.get(1);
 });

--- a/__testfixtures__/integration/get.output.js
+++ b/__testfixtures__/integration/get.output.js
@@ -8,6 +8,7 @@ moduleForComponent('foo-bar', 'Integration | Component | foo bar', {
 
 test('transforms get() correctly', function(assert) {
   assert.ok(findAll('.foo')[1]);
+  assert.ok(findAll('.foo').slice(-2)[0]);
 
   const otherGet = someOtherObj.get(1);
 });

--- a/lib/transforms/acceptance/get.js
+++ b/lib/transforms/acceptance/get.js
@@ -3,7 +3,8 @@ const {
   isFindExpression,
   addImportStatement,
   writeImportStatements,
-} = require('../../utils');
+  determineGetIndex
+} = require("../../utils");
 
 /**
  * Creates a `findAll(selector)[0]` expression
@@ -14,11 +15,24 @@ const {
  * @returns {*}
  */
 function createExpression(j, findArgs, indexArg) {
-  const index = indexArg[0] && indexArg[0].value || 0;
-  return j.memberExpression(
-    createFindAllExpression(j, findArgs),
-    j.literal(index)
-  );
+  const index = determineGetIndex(j, indexArg);
+  if (index > -1) {
+    return j.memberExpression(
+      createFindAllExpression(j, findArgs),
+      j.literal(index)
+    );
+  } else {
+    return j.memberExpression(
+      j.callExpression(
+        j.memberExpression(
+          createFindAllExpression(j, findArgs),
+          j.identifier('slice')
+        ),
+        [j.identifier(index)]
+      ),
+      j.literal(0)
+    );
+  }
 }
 
 /**

--- a/lib/transforms/integration/get.js
+++ b/lib/transforms/integration/get.js
@@ -3,7 +3,8 @@ const {
   isJQuerySelectExpression,
   addImportStatement,
   writeImportStatements,
-} = require('../../utils');
+  determineGetIndex
+} = require("../../utils");
 
 /**
  * Creates a `findAll(selector)[0]` expression
@@ -14,11 +15,24 @@ const {
  * @returns {*}
  */
 function createExpression(j, findArgs, indexArg) {
-  const index = indexArg[0] && indexArg[0].value || 0;
-  return j.memberExpression(
-    createFindAllExpression(j, findArgs),
-    j.literal(index)
-  );
+  const index = determineGetIndex(j, indexArg);
+  if (index > -1) {
+    return j.memberExpression(
+      createFindAllExpression(j, findArgs),
+      j.literal(index)
+    );
+  } else {
+    return j.memberExpression(
+      j.callExpression(
+        j.memberExpression(
+          createFindAllExpression(j, findArgs),
+          j.identifier('slice')
+        ),
+        [j.identifier(index)]
+      ),
+      j.literal(0)
+    );
+  }
 }
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -451,7 +451,7 @@ function makeAwait(j, collection) {
  * $.each's arguments are in the reverse order that Array.forEach's arguments are in.
  * Here we reverse the order of the args if there are two, or add the current element to the front
  * of the arguments array if there is only one arg.
- * @param {*} callBack
+ * @param {function} callBack
  */
 function transformEachsCallbackArgs(callBack) {
   let eachCallBackArgs = callBack[0].params;
@@ -461,6 +461,24 @@ function transformEachsCallbackArgs(callBack) {
     eachCallBackArgs = eachCallBackArgs.reverse();
   }
   return callBack;
+}
+
+/**
+ * Determines if the argument to `get()` is positive or negative.
+ * @param j
+ * @param {ASTNode} indexArg
+ * @returns {number|string} Defaults to 0
+ */
+function determineGetIndex(j, indexArg) {
+  const indexNode = indexArg[0];
+  let index = 0; // default value
+
+  if (j.Literal.check(indexNode)) {
+    index = indexNode.value;
+  } else if (j.UnaryExpression.check(indexNode)) {
+    index = `${indexNode.operator}${indexNode.argument.value}`;
+  }
+  return index;
 }
 
 module.exports = {
@@ -481,5 +499,6 @@ module.exports = {
   migrateSelector,
   dropAndThen,
   makeAwait,
-  transformEachsCallbackArgs
+  transformEachsCallbackArgs,
+  determineGetIndex
 };


### PR DESCRIPTION
Did not account for negative indexes originally; this fixes that.

This PR:
- Add support for transforming negative indexes in `get`

- Add tests